### PR TITLE
Update kz-mask-currency.directive.ts

### DIFF
--- a/src/app/shared/directives/masked-input/kz-mask-currency.directive.ts
+++ b/src/app/shared/directives/masked-input/kz-mask-currency.directive.ts
@@ -83,7 +83,8 @@ export class KzMaskCurrencyDirective implements ControlValueAccessor, OnInit {
   @HostListener('blur', ['$event']) 
   onBlur($event: any) {
     var pattern = '0' + this.separadorDecimal + '00';
-    if ($event.target.value.indexOf(pattern) === -1) {
+    
+    if ($event.target.value.indexOf(pattern) === -1 || ($event.target.value.length > pattern.length)) {
       return;
     }
     this.onChange('');


### PR DESCRIPTION
Da maneira que estava ele estava zerando qualquer valor que acabava em 0,00, por exemplo 70,00, pois ele estava buscando no valor se encontrava a ocorrencia de 0,00 , e em 70,00 tem essa ocorrencia, entao ele estava zerando o input.

Entao alem da checagem do padrao (pattern) eu tambem adicionei uma comparacao da quantidade de caracters, entao mesmo se o padrao for encontrado (como no caso do valor 70,00, 100,00 etc, ele tambem verifica se tem mais caracters que o 0,00).